### PR TITLE
Revert CKAN colors

### DIFF
--- a/ckanext/cfpb_extrafields/fanstatic/ckan_overrides.css
+++ b/ckanext/cfpb_extrafields/fanstatic/ckan_overrides.css
@@ -321,35 +321,6 @@ input[type="button"].btn-block {
   margin-right: 0;
 }
 
-/* Color overrides */
-
-.masthead,
-.homepage .module-search .module-content {
-  background-color: #2CB34A;
-}
-
-body,
-.site-footer,
-.account-masthead,
-.homepage .module-search .tags {
-  background-color: #43484E;
-}
-
-.account-masthead .account ul li a,
-.site-footer a {
-  color: #fff;
-}
-
-@media (min-width: 768px) {
-  .hero {
-    background: #fff;
-  }
-}
-
-[role=main] {
-  min-height: 0;
-}
-
 /* Accessibility */
 
 #skip a {
@@ -377,6 +348,10 @@ body,
 
 .header-text-logo a {
   letter-spacing: .01em;
+}
+
+[role=main] {
+  min-height: 0;
 }
 
 /* Data dicts */


### PR DESCRIPTION
@sleitner Undo'ing the CFPB colors because they don't work very well with CKAN.
