### PR TITLE
Csv export rebased

### DIFF
--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -3,9 +3,157 @@ try:
 except ImportError:
     from stringIO import StringIO
 import csv
+import json
 
 from ckan.plugins.toolkit import BaseController, render, response
 import ckanapi
+
+FIELDS = [
+    'access_notes',
+    'access_restrictions',
+    'also_known_as',
+    'author',
+    'author_email',
+    'contact_primary_email',
+    'contact_primary_name',
+    'contact_secondary_email',
+    'contact_secondary_name',
+    'content_periodicity',
+    'content_spatial',
+    'content_temporal_range_end',
+    'content_temporal_range_start',
+    'creator_user_id',
+    'data_source_names',
+    'dataset_notes',
+    'dig_id',
+    'groups',
+    'id',
+    'initial_purpose_for_intake',
+    'isopen',
+    'legal_authority_for_collection',
+    'license_id',
+    'license_title',
+    'maintainer',
+    'maintainer_email',
+    'metadata_created',
+    'metadata_modified',
+    'name',
+    'notes',
+    'num_resources',
+    'num_tags',
+    'obfuscated_title',
+    'organization.approval_status',
+    'organization.created',
+    'organization.description',
+    'organization.id',
+    'organization.image_url',
+    'organization.is_organization',
+    'organization.name',
+    'organization.revision_id',
+    'organization.state',
+    'organization.title',
+    'organization.type',
+    'owner_org',
+    'pra_exclusion',
+    'pra_omb_control_number',
+    'pra_omb_expiration_date',
+    'privacy_contains_pii',
+    'privacy_has_direct_identifiers',
+    'privacy_has_privacy_act_statement',
+    'privacy_pia_notes',
+    'privacy_pia_title',
+    'privacy_sorn_number',
+    'private',
+    'procurement_document_id',
+    'records_retention_schedule',
+    'relationships_as_object',
+    'relationships_as_subject',
+    'relevant_governing_documents',
+    'resources',
+    'revision_id',
+    'sensitivity_level',
+    'state',
+    'tags',
+    'title',
+    'tracking_summary.recent',
+    'tracking_summary.total',
+    'transfer_details',
+    'transfer_initial_size',
+    'transfer_method',
+    'type',
+    'update_frequency',
+    'url',
+    'usage_restrictions',
+    'version',
+    'website_name',
+    'website_url',
+    'wiki_link'
+]
+FIELD_NAMES = """
+Dataset Title
+Visibility
+Description
+Subject Matter
+Organization
+Also Known As
+Data Sources
+Content Start Date
+Content End Date
+Content Periodicity
+Content Spatial Coverage
+Update Frequency
+Wiki Link
+Reference Website URL
+Primary Contact
+Secondary Contact
+How to Get Access
+Access Restrictions
+Usage Restrictions
+Dataset Notes
+Dataset Last Modified Date
+Obfuscated Title
+Transfer Details
+Transfer Initial Size (mb)
+Transfer Method
+Sensitivity Level
+Legal Authority for Collection
+Relevant Governing Documents
+DIG ID
+Initial Intake for Purpose
+PRA Exclusion
+PRA: OMB Control Number
+PRA: OMB Expiration Date
+Privacy: Contains PII?
+Privacy: Has Direct Identifiers?
+Privacy: Has Privacy Act statement?
+Privacy: PIA title
+Privacy: SORN number
+Records retention schedule
+Procurement document ID
+"""
+
+try:
+    basestring
+except NameError:
+    basestring = str
+def flatten(data, list_sep=","):
+    result = {}
+    for k, v in data.items():
+        if isinstance(v, basestring):
+            result[k] = v.encode("utf-8")
+        elif hasattr(v, "items"):
+            for ikey, ival in flatten(v).items():
+                result[k + "." + ikey] = ival
+        elif hasattr(v, "__iter__") and v:
+            #assume it's a list
+            if isinstance(v[0], basestring):
+                result[k] = list_sep.join(map(str, v)).encode("utf-8")
+            else:
+                result[k] = json.dumps(v).encode("utf-8")
+        else:
+            #int?
+            result[k] = v
+    return result
 
 def get_datasets(rows=10000):
     api = ckanapi.LocalCKAN()
@@ -23,7 +171,7 @@ def to_csv(data, fields):
     writer = csv.DictWriter(output, fields, extrasaction="ignore")
     writer.writeheader()
     for result in data["results"]:
-        writer.writerow(result)
+        writer.writerow(flatten(result))
     return output.getvalue()
 
 class ExportController(BaseController):
@@ -32,7 +180,7 @@ class ExportController(BaseController):
 
     def csv(self):
         datasets = get_datasets()
-        csvdata = to_csv(datasets, ["id", "name", "contact_primary_email"])
+        csvdata = to_csv(datasets, FIELDS)
         response.content_disposition = "attachment; filename=packages.csv"
         response.content_type = "text/csv"
         response.content_length = len(csvdata)

--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -1,3 +1,8 @@
+"""Export all datasets to excel-compatible csv.
+
+Currently only exports public datasets, but once CKAN is upgraded to v2.4+,
+the code can be updated to support private datasets.
+"""
 try:
     from cStringIO import StringIO
 except ImportError:
@@ -8,74 +13,10 @@ import json
 from ckan.plugins.toolkit import BaseController, render, response
 import ckanapi
 
-FIELDS = [
-    ("title", "Dataset Title"),
-    ("private", "Visibility"),
-    ("notes", "Description"),
-    # ("i", "Subject Matter"),
-    ("organization.name", "Organization"),
-    ("also_known_as", "Also Known As"),
-    ("data_source_names", "Data Sources"),
-    ("content_temporal_range_start", "Content Start Date"),
-    ("content_temporal_range_end", "Content End Date"),
-    ("content_periodicity", "Content Periodicity"),
-    ("content_spatial", "Content Spatial Coverage"),
-    ("update_frequency", "Update Frequency"),
-    ("wiki_link", "Wiki Link"),
-    ("website_url", "Reference Website URL"),
-    ("contact_primary_email", "Primary Contact"),
-    ("contact_secondary_email", "Secondary Contact"),
-    ("access_notes", "How to Get Access"),
-    ("access_restrictions", "Access Restrictions"),
-    ("usage_restrictions", "Usage Restrictions"),
-    ("dataset_notes", "Dataset Notes"),
-    # ("i", "Dataset Last Modified Date"),
-    ("obfuscated_title", "Obfuscated Title"),
-    ("transfer_details", "Transfer Details"),
-    ("dig_id", "Transfer Initial Size (mb)"),
-    ("transfer_initial_size", "Transfer Method"),
-    ("transfer_method", "Sensitivity Level"),
-    ("sensitivity_level", "Legal Authority for Collection"),
-    ("legal_authority_for_collection", "Relevant Governing Documents"),
-    ("relevant_governing_documents", "DIG ID"),
-    ("initial_purpose_for_intake", "Initial Purpose for Intake"),
-    ("pra_exclusion", "PRA Exclusion"),
-    ("pra_omb_control_number", "PRA: OMB Control Number"),
-    ("pra_omb_expiration_date", "PRA: OMB Expiration Date"),
-    ("privacy_contains_pii", "Privacy: Contains PII?"),
-    ("privacy_has_direct_identifiers", "Privacy: Has Direct Identifiers?"),
-    ("privacy_has_privacy_act_statement", "Privacy: Has Privacy Act statement?"),
-    ("privacy_pia_title", "Privacy: PIA title"),
-    ("privacy_sorn_number", "Privacy: SORN number"),
-    ("records_retention_schedule", "Records retention schedule"),
-    ("procurement_document_id", "Procurement document ID"),
-]
-
-try:
-    basestring
-except NameError:
-    basestring = str
-
-def flatten(data, list_sep=","):
-    result = {}
-    for k, v in data.items():
-        if isinstance(v, basestring):
-            result[k] = v.encode("utf-8")
-        elif hasattr(v, "items"):
-            for ikey, ival in flatten(v).items():
-                result[k + "." + ikey] = ival
-        elif hasattr(v, "__iter__") and v:
-            #assume it's a list
-            if isinstance(v[0], basestring):
-                result[k] = list_sep.join(map(str, v)).encode("utf-8")
-            else:
-                result[k] = json.dumps(v).encode("utf-8")
-        else:
-            #int?
-            result[k] = v
-    return result
+from ckanext.cfpb_extrafields.exportutils import to_csv, FIELDS
 
 def get_datasets(rows=10000):
+    """Get datasets (packages) from CKAN"""
     api = ckanapi.LocalCKAN()
     result = api.call_action(
         "package_search",
@@ -86,30 +27,17 @@ def get_datasets(rows=10000):
     )
     return result
 
-def to_csv(data, fields):
-    output = StringIO()
-    writer = csv.DictWriter(output, [f[0] for f in fields], extrasaction="ignore")
-    writer.writerow(dict(FIELDS))
-    for result in data["results"]:
-        writer.writerow(flatten(result))
-    return output.getvalue()
-
 class ExportController(BaseController):
     def index(self):
+        """Basic page with a button for exporting data"""
         return render('ckanext/cfpb-extrafields/export_index.html')
 
     def csv(self):
+        """Returns a download with csv of all datasets"""
         datasets = get_datasets()
-        csvdata = to_csv(datasets, FIELDS)
-        response.content_disposition = "attachment; filename=packages.csv"
+        csvdata = to_csv(datasets["results"], FIELDS)
+        response.content_disposition = "attachment; filename=datasets.csv"
         response.content_type = "text/csv"
         response.content_length = len(csvdata)
 
         return csvdata
-
-# if __name__ == "__main__":
-    # import fileinput
-    # data = json.loads("\n".join(fileinput.input()))
-    # result = to_csv(data["result"], FIELDS)
-    # with open("results2.csv", "w") as f:
-        # f.write(result)

--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -9,133 +9,53 @@ from ckan.plugins.toolkit import BaseController, render, response
 import ckanapi
 
 FIELDS = [
-    'access_notes',
-    'access_restrictions',
-    'also_known_as',
-    'author',
-    'author_email',
-    'contact_primary_email',
-    'contact_primary_name',
-    'contact_secondary_email',
-    'contact_secondary_name',
-    'content_periodicity',
-    'content_spatial',
-    'content_temporal_range_end',
-    'content_temporal_range_start',
-    'creator_user_id',
-    'data_source_names',
-    'dataset_notes',
-    'dig_id',
-    'groups',
-    'id',
-    'initial_purpose_for_intake',
-    'isopen',
-    'legal_authority_for_collection',
-    'license_id',
-    'license_title',
-    'maintainer',
-    'maintainer_email',
-    'metadata_created',
-    'metadata_modified',
-    'name',
-    'notes',
-    'num_resources',
-    'num_tags',
-    'obfuscated_title',
-    'organization.approval_status',
-    'organization.created',
-    'organization.description',
-    'organization.id',
-    'organization.image_url',
-    'organization.is_organization',
-    'organization.name',
-    'organization.revision_id',
-    'organization.state',
-    'organization.title',
-    'organization.type',
-    'owner_org',
-    'pra_exclusion',
-    'pra_omb_control_number',
-    'pra_omb_expiration_date',
-    'privacy_contains_pii',
-    'privacy_has_direct_identifiers',
-    'privacy_has_privacy_act_statement',
-    'privacy_pia_notes',
-    'privacy_pia_title',
-    'privacy_sorn_number',
-    'private',
-    'procurement_document_id',
-    'records_retention_schedule',
-    'relationships_as_object',
-    'relationships_as_subject',
-    'relevant_governing_documents',
-    'resources',
-    'revision_id',
-    'sensitivity_level',
-    'state',
-    'tags',
-    'title',
-    'tracking_summary.recent',
-    'tracking_summary.total',
-    'transfer_details',
-    'transfer_initial_size',
-    'transfer_method',
-    'type',
-    'update_frequency',
-    'url',
-    'usage_restrictions',
-    'version',
-    'website_name',
-    'website_url',
-    'wiki_link'
+    ("title", "Dataset Title"),
+    ("private", "Visibility"),
+    ("notes", "Description"),
+    # ("i", "Subject Matter"),
+    ("organization.name", "Organization"),
+    ("also_known_as", "Also Known As"),
+    ("data_source_names", "Data Sources"),
+    ("content_temporal_range_start", "Content Start Date"),
+    ("content_temporal_range_end", "Content End Date"),
+    ("content_periodicity", "Content Periodicity"),
+    ("content_spatial", "Content Spatial Coverage"),
+    ("update_frequency", "Update Frequency"),
+    ("wiki_link", "Wiki Link"),
+    ("website_url", "Reference Website URL"),
+    ("contact_primary_email", "Primary Contact"),
+    ("contact_secondary_email", "Secondary Contact"),
+    ("access_notes", "How to Get Access"),
+    ("access_restrictions", "Access Restrictions"),
+    ("usage_restrictions", "Usage Restrictions"),
+    ("dataset_notes", "Dataset Notes"),
+    # ("i", "Dataset Last Modified Date"),
+    ("obfuscated_title", "Obfuscated Title"),
+    ("transfer_details", "Transfer Details"),
+    ("dig_id", "Transfer Initial Size (mb)"),
+    ("transfer_initial_size", "Transfer Method"),
+    ("transfer_method", "Sensitivity Level"),
+    ("sensitivity_level", "Legal Authority for Collection"),
+    ("legal_authority_for_collection", "Relevant Governing Documents"),
+    ("relevant_governing_documents", "DIG ID"),
+    ("initial_purpose_for_intake", "Initial Purpose for Intake"),
+    ("pra_exclusion", "PRA Exclusion"),
+    ("pra_omb_control_number", "PRA: OMB Control Number"),
+    ("pra_omb_expiration_date", "PRA: OMB Expiration Date"),
+    ("privacy_contains_pii", "Privacy: Contains PII?"),
+    ("privacy_has_direct_identifiers", "Privacy: Has Direct Identifiers?"),
+    ("privacy_has_privacy_act_statement", "Privacy: Has Privacy Act statement?"),
+    ("privacy_pia_title", "Privacy: PIA title"),
+    ("privacy_sorn_number", "Privacy: SORN number"),
+    ("records_retention_schedule", "Records retention schedule"),
+    ("procurement_document_id", "Procurement document ID"),
 ]
-FIELD_NAMES = """
-Dataset Title
-Visibility
-Description
-Subject Matter
-Organization
-Also Known As
-Data Sources
-Content Start Date
-Content End Date
-Content Periodicity
-Content Spatial Coverage
-Update Frequency
-Wiki Link
-Reference Website URL
-Primary Contact
-Secondary Contact
-How to Get Access
-Access Restrictions
-Usage Restrictions
-Dataset Notes
-Dataset Last Modified Date
-Obfuscated Title
-Transfer Details
-Transfer Initial Size (mb)
-Transfer Method
-Sensitivity Level
-Legal Authority for Collection
-Relevant Governing Documents
-DIG ID
-Initial Intake for Purpose
-PRA Exclusion
-PRA: OMB Control Number
-PRA: OMB Expiration Date
-Privacy: Contains PII?
-Privacy: Has Direct Identifiers?
-Privacy: Has Privacy Act statement?
-Privacy: PIA title
-Privacy: SORN number
-Records retention schedule
-Procurement document ID
-"""
 
 try:
     basestring
 except NameError:
     basestring = str
+
 def flatten(data, list_sep=","):
     result = {}
     for k, v in data.items():
@@ -168,8 +88,8 @@ def get_datasets(rows=10000):
 
 def to_csv(data, fields):
     output = StringIO()
-    writer = csv.DictWriter(output, fields, extrasaction="ignore")
-    writer.writeheader()
+    writer = csv.DictWriter(output, [f[0] for f in fields], extrasaction="ignore")
+    writer.writerow(dict(FIELDS))
     for result in data["results"]:
         writer.writerow(flatten(result))
     return output.getvalue()
@@ -186,3 +106,10 @@ class ExportController(BaseController):
         response.content_length = len(csvdata)
 
         return csvdata
+
+# if __name__ == "__main__":
+    # import fileinput
+    # data = json.loads("\n".join(fileinput.input()))
+    # result = to_csv(data["result"], FIELDS)
+    # with open("results2.csv", "w") as f:
+        # f.write(result)

--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -1,0 +1,40 @@
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from stringIO import StringIO
+import csv
+
+from ckan.plugins.toolkit import BaseController, render, response
+import ckanapi
+
+def get_datasets(rows=10000):
+    api = ckanapi.LocalCKAN()
+    result = api.call_action(
+        "package_search",
+        {
+            "q": "",
+            "rows": rows,
+        }
+    )
+    return result
+
+def to_csv(data, fields):
+    output = StringIO()
+    writer = csv.DictWriter(output, fields, extrasaction="ignore")
+    writer.writeheader()
+    for result in data["results"]:
+        writer.writerow(result)
+    return output.getvalue()
+
+class ExportController(BaseController):
+    def index(self):
+        return render('ckanext/cfpb-extrafields/export_index.html')
+
+    def csv(self):
+        datasets = get_datasets()
+        csvdata = to_csv(datasets, ["id", "name", "contact_primary_email"])
+        response.content_disposition = "attachment; filename=packages.csv"
+        response.content_type = "text/csv"
+        response.content_length = len(csvdata)
+
+        return csvdata

--- a/ckanext/cfpb_extrafields/exportutils.py
+++ b/ckanext/cfpb_extrafields/exportutils.py
@@ -1,0 +1,108 @@
+"""Export all datasets to excel-compatible csv.
+
+Currently only exports public datasets, but once CKAN is upgraded to v2.4+,
+the code can be updated to support private datasets.
+"""
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from stringIO import StringIO
+import csv
+import json
+
+
+FIELDS = [
+    ("title", "Dataset Title"),
+    ("private", "Visibility"),
+    ("notes", "Description"),
+    # ("i", "Subject Matter"),
+    ("organization.name", "Organization"),
+    ("also_known_as", "Also Known As"),
+    ("data_source_names", "Data Sources"),
+    ("content_temporal_range_start", "Content Start Date"),
+    ("content_temporal_range_end", "Content End Date"),
+    ("content_periodicity", "Content Periodicity"),
+    ("content_spatial", "Content Spatial Coverage"),
+    ("update_frequency", "Update Frequency"),
+    ("wiki_link", "Wiki Link"),
+    ("website_url", "Reference Website URL"),
+    ("contact_primary_email", "Primary Contact"),
+    ("contact_secondary_email", "Secondary Contact"),
+    ("access_notes", "How to Get Access"),
+    ("access_restrictions", "Access Restrictions"),
+    ("usage_restrictions", "Usage Restrictions"),
+    ("dataset_notes", "Dataset Notes"),
+    # ("i", "Dataset Last Modified Date"),
+    ("obfuscated_title", "Obfuscated Title"),
+    ("transfer_details", "Transfer Details"),
+    ("dig_id", "Transfer Initial Size (mb)"),
+    ("transfer_initial_size", "Transfer Method"),
+    ("transfer_method", "Sensitivity Level"),
+    ("sensitivity_level", "Legal Authority for Collection"),
+    ("legal_authority_for_collection", "Relevant Governing Documents"),
+    ("relevant_governing_documents", "DIG ID"),
+    ("initial_purpose_for_intake", "Initial Purpose for Intake"),
+    ("pra_exclusion", "PRA Exclusion"),
+    ("pra_omb_control_number", "PRA: OMB Control Number"),
+    ("pra_omb_expiration_date", "PRA: OMB Expiration Date"),
+    ("privacy_contains_pii", "Privacy: Contains PII?"),
+    ("privacy_has_direct_identifiers", "Privacy: Has Direct Identifiers?"),
+    ("privacy_has_privacy_act_statement", "Privacy: Has Privacy Act statement?"),
+    ("privacy_pia_title", "Privacy: PIA title"),
+    ("privacy_sorn_number", "Privacy: SORN number"),
+    ("records_retention_schedule", "Records retention schedule"),
+    ("procurement_document_id", "Procurement document ID"),
+]
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
+def flatten(data, list_sep=","):
+    """Convert a nested dictionary to a flat data structure
+    flattened keys are separated by dots
+    Value encodings:
+    * lists of strings are joined by list_sep if it's present
+    * all other lists are json-encoded
+    * dicts are recursively flattened
+    * all other values are included verbatim
+
+    Example:
+        {"child":{"name": "Bob", "fav_foods": ["apples", "bananas"],
+            "parents": [{"name": "John"}, {"name": "Sue"}]}}
+        ->
+        {"child.name": "Bob", "child.fav_foods": "apples,bananas", "parents": "<json encoded list>"}
+    """
+    result = {}
+    for key, val in data.items():
+        if isinstance(val, basestring):
+            result[key] = val.encode("utf-8")
+        elif hasattr(val, "items"):
+            for ikey, ival in flatten(val, list_sep=list_sep).items():
+                result[key + "." + ikey] = ival
+        elif hasattr(val, "__iter__") and val:
+            #assume it's a list
+            if isinstance(val[0], basestring) and list_sep:
+                result[key] = list_sep.join(map(str, val)).encode("utf-8")
+            else:
+                result[key] = json.dumps(val).encode("utf-8")
+        else:
+            #int?
+            result[key] = val
+    return result
+
+def to_csv(data, fields, fieldmap=tuple(FIELDS)):
+    """Convert data to an excel-style csv
+
+    :param data: list of dictionaries of data (each dict is 1 row)
+    :param fields: which fields (keys in the dict) to write
+    :param fieldmap: dict mapping keys in the dict to human-readable names
+        which will appear as the first line of the csv
+    """
+    output = StringIO()
+    writer = csv.DictWriter(output, [f[0] for f in fields], extrasaction="ignore")
+    writer.writerow(dict(fieldmap))
+    for result in data:
+        writer.writerow(flatten(result))
+    return output.getvalue()

--- a/ckanext/cfpb_extrafields/plugin.py
+++ b/ckanext/cfpb_extrafields/plugin.py
@@ -524,3 +524,10 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
     def before_view(self, pkg_dict):
         return pkg_dict
 
+class ExportPlugin(p.SingletonPlugin):
+    p.implements(p.IRoutes, inherit=True)
+
+    def after_map(self, map):
+        map.connect("export_page", "/export", controller="ckanext.cfpb_extrafields.controllers.export:ExportController", action="index")
+        map.connect("export_csv", "/export/csv", controller="ckanext.cfpb_extrafields.controllers.export:ExportController", action="csv")
+        return map

--- a/ckanext/cfpb_extrafields/templates/ckanext/cfpb-extrafields/export_index.html
+++ b/ckanext/cfpb_extrafields/templates/ckanext/cfpb-extrafields/export_index.html
@@ -1,0 +1,6 @@
+{% extends "page.html" %}
+
+{% block primary_content %}
+	<h2>CSV Export</h2>
+	To export all the data, <a href="/export/csv", target="_blank">click here</a>
+{% endblock %}

--- a/ckanext/cfpb_extrafields/templates/package/search.html
+++ b/ckanext/cfpb_extrafields/templates/package/search.html
@@ -1,9 +1,10 @@
 {% ckan_extends %}
-{% block breadcrumb_content%}
+{% block breadcrumb %}
 {{ super() }}
-<span style="padding-left:450px;float:right;overflow:hidden">
+<span style="float:right;overflow:hidden">
 {% if h.check_access('package_create') %}
-    {% link_for _('add dataset'), controller='package', action='new', icon='plus-sign-alt' %}
+    {% link_for _('Add Dataset'), controller='package', action='new', icon='plus-sign-alt' %}
+    {% link_for _('Export CSV'), named_route='export_csv', icon='download-alt' %}
 {% endif %}
 </span>
 {% endblock %}

--- a/ckanext/cfpb_extrafields/tests.py
+++ b/ckanext/cfpb_extrafields/tests.py
@@ -3,11 +3,11 @@ from nose_parameterized import parameterized
 from nose.tools import assert_equal
 import mock
 import validators as v
+import ckanext.cfpb_extrafields.exportutils as eu
 
 
 class TestValidators(unittest.TestCase):
 
-    
     @parameterized.expand([
         (u'"asdf","asdf,asdf"',[u'asdf', u'asdf,asdf']),
         (u'asdf',[u'asdf']),
@@ -122,3 +122,31 @@ class TestValidators(unittest.TestCase):
         mi.side_effect = Exception("")
         with self.assertRaises(Exception):
             v.pra_control_num_validator(input)
+
+class TestExport(unittest.TestCase):
+    @parameterized.expand([
+        ({"a": {"str": "x"}}, {"a.str": "x"}),
+        ({"a": {"int": 1}}, {"a.int": 1}),
+        ({"a": {"list_str": ["x", "y", "z"]}}, {"a.list_str": "x,y,z"}),
+        ({"a": {"list_dict": [{"x": "y"}, {}]}}, {"a.list_dict": '[{"x": "y"}, {}]'}),
+    ])
+    def test_flatten(self, data, expected):
+        result = eu.flatten(data)
+        assert_equal(result, expected)
+
+    @parameterized.expand([
+        ({}, {"a.list_str": "x,y,z"}),
+        ({"list_sep": "; "}, {"a.list_str": "x; y; z"}),
+        ({"list_sep": None}, {"a.list_str": '["x", "y", "z"]'}),
+    ])
+    def test_flatten_listseps(self, kwargs, expected):
+        data = {"a": {"list_str": ["x", "y", "z"]}}
+        result = eu.flatten(data, **kwargs)
+        assert_equal(result, expected)
+    
+    @parameterized.expand([
+        ([{"a":1, "b": 2, "c": 3}], ["b", "a"], {"a": "A", "b": "bee"}, "bee,A\r\n2,1\r\n"),
+    ])
+    def test_to_csv(self, data, fields, fieldmap, expected):
+        result = eu.to_csv(data, fields, fieldmap)
+        assert_equal(result, expected)

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,12 @@ setup(
     zip_safe=False,
     install_requires=[
         # -*- Extra requirements: -*-
+        "ckanapi"
     ],
     entry_points='''
         [ckan.plugins]
         # Add plugins here, e.g.
         ckanext_cfpb_extrafields=ckanext.cfpb_extrafields.plugin:ExampleIDatasetFormPlugin
+        ckanext_cfpb_export=ckanext.cfpb_extrafields.plugin:ExportPlugin
     ''',
 )


### PR DESCRIPTION
Add a plugin to export a list of all datasets as CSV.

Currently only supports public datasets (we need to upgrade CKAN to 2.4+ before we can include private datasets.)

To test:

* pull this branch
* re-install this repo (so that the new plugin is registered)
* add `ckanext_cfpb_export` to `cfpb.plugins` in `config.ini`
* restart apache
* click on the "Datasets" tab in the data catalog
* click the "Export CSV" link to the right of the breadcrumbs