### PR TITLE
CSV Export: Include Private Datasets

### DIFF
--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -10,21 +10,22 @@ except ImportError:
 import csv
 import json
 
-from ckan.plugins.toolkit import BaseController, render, response
-import ckanapi
+from ckan.plugins.toolkit import BaseController, check_ckan_version, get_action, render, response
+# import ckanapi
 
 from ckanext.cfpb_extrafields.exportutils import to_csv, FIELDS
 
 def get_datasets(rows=10000):
     """Get datasets (packages) from CKAN"""
-    api = ckanapi.LocalCKAN()
-    result = api.call_action(
-        "package_search",
-        {
-            "q": "",
-            "rows": rows,
-        }
-    )
+    # api = ckanapi.LocalCKAN()
+    data_dict = {
+        "q": "",
+        "rows": rows,
+    }
+    if check_ckan_version('2.6'):
+        data_dict["include_private"] = True
+    # result = api.call_action("package_search", data_dict)
+    result = get_action("package_search")({}, data_dict)
     return result
 
 class ExportController(BaseController):

--- a/ckanext/cfpb_extrafields/controllers/export.py
+++ b/ckanext/cfpb_extrafields/controllers/export.py
@@ -11,20 +11,18 @@ import csv
 import json
 
 from ckan.plugins.toolkit import BaseController, check_ckan_version, get_action, render, response
-# import ckanapi
 
 from ckanext.cfpb_extrafields.exportutils import to_csv, FIELDS
 
 def get_datasets(rows=10000):
     """Get datasets (packages) from CKAN"""
-    # api = ckanapi.LocalCKAN()
     data_dict = {
         "q": "",
         "rows": rows,
     }
     if check_ckan_version('2.6'):
         data_dict["include_private"] = True
-    # result = api.call_action("package_search", data_dict)
+
     result = get_action("package_search")({}, data_dict)
     return result
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # -*- Extra requirements: -*-
-        "ckanapi"
     ],
     entry_points='''
         [ckan.plugins]


### PR DESCRIPTION
Export private datasets to csv and remove ckanapi dependency

On ckan 2.6+, the parameter include_private can be set to true so that the private datasets visible to that user are included in the results. If on ckan 2.6+, we add this parameter when exporting to CSV.

This file used to use ckanapi to call package_search, but using ckan's plugin toolkit get_action method instead allows us to remove this dependency.