### PR TITLE
Single sign-on

### DIFF
--- a/ckanext/cfpb_extrafields/plugin.py
+++ b/ckanext/cfpb_extrafields/plugin.py
@@ -524,6 +524,14 @@ class ExampleIDatasetFormPlugin(p.SingletonPlugin, tk.DefaultDatasetForm):
     def before_view(self, pkg_dict):
         return pkg_dict
 
+class SSOPlugin(p.SingletonPlugin):
+    p.implements(p.IAuthenticator, inherit=True)
+
+    def identify(self):
+        username = tk.request.headers.get("TST_USERNAME")
+        if username:
+            tk.c.user = username
+
 class ExportPlugin(p.SingletonPlugin):
     p.implements(p.IRoutes, inherit=True)
 

--- a/ckanext/cfpb_extrafields/plugin.py
+++ b/ckanext/cfpb_extrafields/plugin.py
@@ -528,7 +528,8 @@ class SSOPlugin(p.SingletonPlugin):
     p.implements(p.IAuthenticator, inherit=True)
 
     def identify(self):
-        username = tk.request.headers.get("TST_USERNAME")
+        header_name = tk.config.get("ckanext.cfpb_sso.http_header", "From")
+        username = tk.request.headers.get(header_name)
         if username:
             tk.c.user = username
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     ],
     entry_points='''
         [ckan.plugins]
-        # Add plugins here, e.g.
         ckanext_cfpb_extrafields=ckanext.cfpb_extrafields.plugin:ExampleIDatasetFormPlugin
+        ckanext_cfpb_sso=ckanext.cfpb_extrafields.plugin:SSOPlugin
         ckanext_cfpb_export=ckanext.cfpb_extrafields.plugin:ExportPlugin
     ''',
 )


### PR DESCRIPTION
Support single sign-on via http header


An apache proxy can authenticate via kerberos and set an HTTP header to the username.
This plugin will check for that header and automatically log in the user if it's set.

If the header is not set, the plugin will fall back to other methods (check a cookie to see if they're already logged in or let them use the login form and check that information against ldap).