### PR TITLE
Show the CSV button for all users

### DIFF
--- a/ckanext/cfpb_extrafields/templates/package/search.html
+++ b/ckanext/cfpb_extrafields/templates/package/search.html
@@ -4,8 +4,8 @@
 <span style="float:right;overflow:hidden">
 {% if h.check_access('package_create') %}
     {% link_for _('Add Dataset'), controller='package', action='new', icon='plus-sign-alt' %}
-    {% link_for _('Export CSV'), named_route='export_csv', icon='download-alt' %}
 {% endif %}
+{% link_for _('Export CSV'), named_route='export_csv', icon='download-alt' %}
 </span>
 {% endblock %}
 {% block page_primary_action %}


### PR DESCRIPTION
After reviewing with Tim, there is no need to hide this button from any users.
All of this information is already available to users via the API, and hiding
the button will only make the feature harder to test and inconvenience end
users.