### PR TITLE
Comment out code snippets for now

### DIFF
--- a/ckanext/cfpb_extrafields/templates/package/resource_read.html
+++ b/ckanext/cfpb_extrafields/templates/package/resource_read.html
@@ -213,6 +213,8 @@
     </div>
   </div>
 </section>
+{#
+Commenting out for now as this functionality is broken in ckan-2.6.0 (they deprecated *_related actions)
 <section class="module resource-view">
   <div class="module-content">
     <!-- ============ SHARE ============= -->
@@ -317,7 +319,7 @@ function example_code_snippet(items) {
     </div>
   </div>
 </div>
-
+#}
 {% endif %}
 {% block resource_view_content %}
 {% resource 'cfpb_extrafields/dataset-status.js' %}


### PR DESCRIPTION
This functionality breaks in 2.6 and should be commented out.

In the future, we should go through all the code and completely delete
this feature.