### PR TITLE
Lowercase fields that are radio buttons in the catalog

### DIFF
--- a/ckanext/cfpb_extrafields/digutils.py
+++ b/ckanext/cfpb_extrafields/digutils.py
@@ -51,6 +51,11 @@ def date(cell):
         return val
     return get_date
 
+def lower(cell):
+    def get_lower(ws):
+        return (ws[cell].value or "").lower()
+    return get_lower
+
 # Maps field name to either a cell or a function that's passed the worksheet and should return the value
 # Note that some values are currently blank and commented out as they don't map to any fields in the DIG excel sheet
 FIELDS = {
@@ -66,9 +71,9 @@ FIELDS = {
     "pra_exclusion": concat(["D38", "B39"]),
     "pra_omb_control_number": lambda ws: v.pra_control_num_validator(strfy(ws["F37"].value)),
     "pra_omb_expiration_date": date("F38"),
-    "privacy_contains_pii": "B29",
-    "privacy_has_direct_identifiers": "B30",
-    "privacy_has_privacy_act_statement": "D30",
+    "privacy_contains_pii": lower("B29"),
+    "privacy_has_direct_identifiers": lower("B30"),
+    "privacy_has_privacy_act_statement": lower("D30"),
     "privacy_pia_notes": "B33",
     "privacy_pia_title": "D32",
     "privacy_sorn_number": "D31",

--- a/ckanext/cfpb_extrafields/tests.py
+++ b/ckanext/cfpb_extrafields/tests.py
@@ -214,6 +214,17 @@ class TestImport(unittest.TestCase):
         assert_equal(result, expected)
 
     @parameterized.expand([
+        ("Yes", "yes"),
+        ("yes", "yes"),
+        ("", ""),
+        (None, ""),
+    ])
+    def test_lower(self, cell_val, expected):
+        sheet = {"A1": MockCell(cell_val)}
+        result = du.lower("A1")(sheet)
+        assert_equal(result, expected)
+
+    @parameterized.expand([
         ("A39", "foo"),
         (lambda x: x["A39"].value.upper(), "FOO"),
     ])


### PR DESCRIPTION
Radio fields can have values "yes", "no", or "n/a".
Anything that's not a lowercase yes/no gets converted to n/a, so ensure
that "Yes" is treated as "yes".